### PR TITLE
Convert records to coco style

### DIFF
--- a/mantisshrimp/data/__init__.py
+++ b/mantisshrimp/data/__init__.py
@@ -1,2 +1,3 @@
 from .prepare_record import *
 from .dataset import *
+from .convert_records_to_coco_style import *

--- a/mantisshrimp/data/convert_records_to_coco_style.py
+++ b/mantisshrimp/data/convert_records_to_coco_style.py
@@ -1,0 +1,76 @@
+__all__ = ["convert_records_to_coco_style", "coco_api_from_records"]
+
+from pycocotools.coco import COCO
+from mantisshrimp.imports import *
+from mantisshrimp import *
+
+
+def coco_api_from_records(records):
+    coco_ds = COCO()
+    coco_ds.dataset = convert_records_to_coco_style(records)
+    coco_ds.createIndex()
+    return coco_ds
+
+
+def convert_records_to_coco_style(records):
+    """ Converts records from library format to coco format.
+    Inspired from: https://github.com/pytorch/vision/blob/master/references/detection/coco_utils.py#L146
+    """
+    images = []
+    annotations_dict = defaultdict(list)
+    categories_set = set()
+
+    for record in pbar(records):
+        # build images field
+        image = {}
+        image["id"] = record["imageid"]
+        image["file_name"] = Path(record["filepath"]).name
+        image["width"] = record["width"]
+        image["height"] = record["height"]
+        images.append(image)
+
+        # build annotations field
+        for label in record["label"]:
+            annotations_dict["image_id"].append(record["imageid"])
+            annotations_dict["category_id"].append(label)
+            categories_set.add(label)
+
+        if "bbox" in record:
+            for bbox in record["bbox"]:
+                annotations_dict["bbox"].append(bbox.xywh)
+
+        if "area" in record:
+            for area in record["area"]:
+                annotations_dict["area"].append(area)
+
+        if "mask" in record:
+            for mask in record["mask"]:
+                if isinstance(mask, Polygon):
+                    annotations_dict["segmentation"].append(mask.points)
+                elif isinstance(mask, RLE):
+                    coco_rle = {
+                        "counts": mask.to_coco(),
+                        "size": [record["height"], record["width"]],
+                    }
+                    annotations_dict["segmentation"].append(coco_rle)
+                else:
+                    msg = f"Mask type {type(mask)} unsupported, we only support RLE and Polygon"
+                    raise ValueError(msg)
+
+        for iscrowd in record["iscrowd"]:
+            annotations_dict["iscrowd"].append(iscrowd)
+
+    if not allequal([len(o) for o in annotations_dict.values()]):
+        raise RuntimeError("Mismatch lenght of elements")
+
+    categories = [{"id": i} for i in categories_set]
+
+    # convert dict of lists to list of dicts
+    annotations = []
+    for i in range(len(annotations_dict["image_id"])):
+        annotation = {k: v[i] for k, v in annotations_dict.items()}
+        # annotations should be initialized starting at 1 (torchvision issue #1530)
+        annotation["id"] = i + 1
+        annotations.append(annotation)
+
+    return {"images": images, "annotations": annotations, "categories": categories}

--- a/mantisshrimp/data/convert_records_to_coco_style.py
+++ b/mantisshrimp/data/convert_records_to_coco_style.py
@@ -6,6 +6,8 @@ from mantisshrimp import *
 
 
 def coco_api_from_records(records):
+    """ Create pycocotools COCO dataset from records
+    """
     coco_ds = COCO()
     coco_ds.dataset = convert_records_to_coco_style(records)
     coco_ds.createIndex()

--- a/mantisshrimp/metrics/coco_metric/coco_metric.py
+++ b/mantisshrimp/metrics/coco_metric/coco_metric.py
@@ -1,49 +1,11 @@
 __all__ = ["COCOMetric"]
 
-from ...imports import *
-from ...utils import *
-from ...models import *
+from mantisshrimp.imports import *
+from mantisshrimp.utils import *
+from mantisshrimp.models import *
+from mantisshrimp.data import *
 from .coco_eval import CocoEvaluator
 from ..metric import *
-from pycocotools.coco import COCO
-
-
-def records2coco(records, catmap):
-    cats = [{"id": i, "name": o.name} for i, o in catmap.i2o.items()]
-    annots = defaultdict(list)
-    infos = []
-    i = 0
-    for r in tqdm(records):
-        infos.append(
-            {
-                "id": r.info.imageid,
-                "file_name": r.info.filepath.name,
-                "width": r.info.w,
-                "height": r.info.h,
-            }
-        )
-        for annot in r.annot:
-            annots["id"].append(i)  # TODO: Careful with ids! when over all dataset
-            annots["image_id"].append(r.info.imageid)
-            annots["category_id"].append(annot.label)
-            annots["bbox"].append(annot.bbox.xywh)
-            annots["area"].append(annot.bbox.area)
-            # TODO: for other types of masks
-            if notnone(annot.mask):
-                annots["segmentation"].extend(annot.mask.to_erle(r.info.h, r.info.w))
-            annots["iscrowd"].append(annot.iscrowd)
-            # TODO: Keypoints
-            i += 1
-    assert allequal(lmap(len, annots.values())), "Mismatch lenght of elements"
-    annots = [{k: v[i] for k, v in annots.items()} for i in range_of(annots["id"])]
-    return {"images": infos, "annotations": annots, "categories": cats}
-
-
-def coco_api_from_records(records, catmap):
-    coco_ds = COCO()
-    coco_ds.dataset = records2coco(records, catmap)
-    coco_ds.createIndex()
-    return coco_ds
 
 
 def _get_iou_types(model):

--- a/tests/data/test_convert_records_to_coco_style.py
+++ b/tests/data/test_convert_records_to_coco_style.py
@@ -1,0 +1,69 @@
+import pytest
+from mantisshrimp import *
+from mantisshrimp.imports import np, itemgetter, Path, torchvision
+
+
+@pytest.fixture()
+def coco_records(records):
+    return convert_records_to_coco_style(records)
+
+
+@pytest.fixture()
+def expected_records():
+    source = Path("/home/lgvaz/git/mantisshrimp2/samples")
+    dataset = torchvision.datasets.CocoDetection(source, source / "annotations.json")
+    return dataset.coco.dataset
+
+
+def test_convert_records_to_coco_style_images(coco_records, expected_records):
+    # remove id 89 because it doesn't contain any annotations and it will be removed by the parser
+    # also remove some unnecessary fields like flickr_url, coco_url, ...
+    expected_images = [
+        {name: o[name] for name in ["id", "file_name", "height", "width"]}
+        for o in expected_records["images"]
+        if o["id"] != 89
+    ]
+    # some of the checks need the lists to be in the same order
+    expected_images = sorted(expected_images, key=itemgetter("id"))
+    images = sorted(coco_records["images"], key=itemgetter("id"))
+
+    assert len(images) == len(expected_images)
+    assert images[0].keys() == expected_images[0].keys()
+    assert images == expected_images
+
+
+def test_convert_records_to_coco_style_annotations(coco_records, expected_records):
+    annotations = coco_records["annotations"]
+    expected_annotations = expected_records["annotations"]
+
+    assert len(expected_annotations) == len(annotations)
+    assert annotations[0].keys() == expected_annotations[0].keys()
+
+    # check if two unordered lists of dicts are approximate the same
+    # the annotations ids don't matter and don't match
+    for i in range(len(annotations)):
+        del annotations[i]["id"]
+        del expected_annotations[i]["id"]
+
+    # sort items so we compare each annotation with it's corresponded pair
+    sorted_annotations = sorted(sorted(d.items()) for d in annotations)
+    sorted_expectation = sorted(sorted(d.items()) for d in expected_annotations)
+
+    # check each (key, value) individually (so we can use almost_equal)
+    for annotation, expected_annotation in zip(sorted_annotations, sorted_expectation):
+        # remember that each annotation is now in the form: (key, value)
+        for (k1, v1), (k2, v2) in zip(annotation, expected_annotation):
+            assert k1[0] == k2[0]
+            if k1 == "segmentation":
+                assert v1 == v2
+            else:
+                np.testing.assert_almost_equal(v1, v2)
+
+
+def test_coco_api_from_records(records):
+    coco_api = coco_api_from_records(records)
+    image_info = coco_api.loadImgs([343934])
+    expected = [
+        {"id": 343934, "file_name": "000000343934.jpg", "width": 640, "height": 480}
+    ]
+    assert image_info == expected

--- a/tests/data/test_convert_records_to_coco_style.py
+++ b/tests/data/test_convert_records_to_coco_style.py
@@ -1,4 +1,5 @@
 import pytest
+import mantisshrimp
 from mantisshrimp import *
 from mantisshrimp.imports import np, itemgetter, Path, torchvision
 
@@ -10,7 +11,7 @@ def coco_records(records):
 
 @pytest.fixture()
 def expected_records():
-    source = Path("/home/lgvaz/git/mantisshrimp2/samples")
+    source = Path(mantisshrimp.__file__).parent.parent / "samples"
     dataset = torchvision.datasets.CocoDetection(source, source / "annotations.json")
     return dataset.coco.dataset
 


### PR DESCRIPTION
Implements functionality to convert records of the library standard format to coco format.

This will be helpful when using `pycocotools` utilities like their metrics (which a lot of paper users) and will ease out future integrations.