### PR TITLE
Added Augmentation Transforms using Albumentations

### DIFF
--- a/mantisshrimp/transforms/albu_transform.py
+++ b/mantisshrimp/transforms/albu_transform.py
@@ -45,17 +45,19 @@ class AlbuTransform(Transform):
 
 def aug_tfms_train_albu(max_size=384, bbox_safe_crop=(320, 320, 0.3), rotate_limit=20, blur_limit=(1, 3), RGBShift_always=True, images_stats=IMAGENET_STATS):
     
+    bbox_sc_h, bbox_sc_w, bbox_sc_p = bbox_safe_crop
+    blur_limit_min, blur_limit_max = blur_limit
     images_mean, images_std = images_stats
 
     return AlbuTransform(
         [
             A.LongestMaxSize(max_size),
-            A.RandomSizedBBoxSafeCrop(*bbox_safe_crop),
+            A.RandomSizedBBoxSafeCrop(bbox_sc_h, bbox_sc_w, bbox_sc_p),
             A.HorizontalFlip(),
             A.ShiftScaleRotate(rotate_limit=rotate_limit),
             A.RGBShift(always_apply=RGBShift_always),
             A.RandomBrightnessContrast(),
-            A.Blur(blur_limit=*blur_limit),
+            A.Blur(blur_limit=(blur_limit_min, blur_limit_max)),
             A.Normalize(mean=images_mean, std=images_std),
         ]
     )

--- a/mantisshrimp/transforms/albu_transform.py
+++ b/mantisshrimp/transforms/albu_transform.py
@@ -1,4 +1,8 @@
-__all__ = ["AlbuTransform"]
+__all__ = [
+    "AlbuTransform",
+    "aug_tfms_train_albu",
+    "aug_tfms_valid_albu"
+]
 
 from mantisshrimp.imports import *
 from mantisshrimp.core import *

--- a/mantisshrimp/transforms/albu_transform.py
+++ b/mantisshrimp/transforms/albu_transform.py
@@ -104,4 +104,3 @@ def aug_tfms_albumentations(config_aug_tfms=config_aug_tfms_train_pets):
       return AlbuTransform(albu_array)
     else:
         return None
-    

--- a/mantisshrimp/transforms/albu_transform.py
+++ b/mantisshrimp/transforms/albu_transform.py
@@ -55,29 +55,44 @@ config_aug_tfms_train_pets = {
     """ Configuration Objects for Albumentations Transforms uring train stage
 
     Each dictionary key corresponds to a particular Albumentations Transform
+    The conventions is the following:
+    "Snake Notation"              <---> "Camel Case Notation" 
+    "longest_max_size"            <---> LongestMaxSize
+    "random_sized_bbox_safe_crop" <---> RandomSizedBBoxSafeCrop
+
     Each dictionary value represents some valid arguments corresponding to a specific Albumentations Transform
- 
+    e.g: 
+    "random_sized_bbox_safe_crop" <---> RandomSizedBBoxSafeCrop ---> {"height": 320, "width": 320, "p": 0.3}
+
+    [[https://albumentations.readthedocs.io/en/latest/_modules/albumentations/augmentations/transforms.html/|Albumentations Transforms ]]
     """
 
-    "max_size": 384,
-    "bbox_safe_crop": {"height": 320, "width": 320, "p": 0.3},
-    "flip": True,
-    "rotate_limit": {"rotate_limit": 20},
+    "longest_max_size": 384,
+    "random_sized_bbox_safe_crop": {"height": 320, "width": 320, "p": 0.3},
+    "horizontal_flip": True,
+    "shift_scale_rotate": {"rotate_limit": 20},
     "rgb_shift": {"always_apply": True, "p": 0.5},
     "brightness_contrast": {"brightness_limit": 0.2, "contrast_limit": 0.2},
     "blur": {"blur_limit": (1, 3)},
-    "images_stats": IMAGENET_STATS
+    "normalize": {"mean": IMAGENET_STATS[0], "std": IMAGENET_STATS[1]}
 }
 
 config_aug_tfms_valid_pets = {
     """ Configuration Objects for Albumentations Transforms applied during validation stage
 
     Each dictionary key corresponds to a particular Albumentations Transform
+    The conventions is the following:
+    "Snake Notation"              <---> "Camel Case Notation" 
+    "longest_max_size"            <---> LongestMaxSize
+    "random_sized_bbox_safe_crop" <---> RandomSizedBBoxSafeCrop
+
     Each dictionary value represents some valid arguments corresponding to a specific Albumentations Transform
+
+    [[https://albumentations.readthedocs.io/en/latest/_modules/albumentations/augmentations/transforms.html/|Albumentations Transforms ]]
     """
     
-    "max_size": 384,
-    "images_stats": IMAGENET_STATS
+    "longest_max_size": 384,
+    "normalize": {"mean": IMAGENET_STATS[0], "std": IMAGENET_STATS[1]}
 }
 
 
@@ -96,22 +111,24 @@ def aug_tfms_albumentations(config_aug_tfms=config_aug_tfms_train_pets):
         >>> valid_tfms = aug_tfms_albumentations(config_aug_tfms=config_aug_tfms_valid_pets)
         >>> train_ds = Dataset(train_records, train_tfms)
         >>> valid_ds = Dataset(valid_records, valid_tfms)
+
+    [[https://albumentations.readthedocs.io/en/latest/_modules/albumentations/augmentations/transforms.html/|Albumentations Transforms ]]
     """
     
     albu_array=[]
 
-    if "max_size" in config_aug_tfms: 
-      albu_array.append(A.LongestMaxSize(config_aug_tfms["max_size"]))
+    if "longest_max_size" in config_aug_tfms: 
+      albu_array.append(A.LongestMaxSize(config_aug_tfms["longest_max_size"]))
 
-    if "bbox_safe_crop" in config_aug_tfms: 
-      albu_array.append(A.RandomSizedBBoxSafeCrop(**config_aug_tfms["bbox_safe_crop"]))
+    if "random_sized_bbox_safe_crop" in config_aug_tfms: 
+      albu_array.append(A.RandomSizedBBoxSafeCrop(**config_aug_tfms["random_sized_bbox_safe_crop"]))
 
-    if "flip" in config_aug_tfms: 
-      flip = config_aug_tfms["flip"]
-      if flip: albu_array.append(A.HorizontalFlip())
+    if "horizontal_flip" in config_aug_tfms: 
+      horizontal_flip = config_aug_tfms["horizontal_flip"]
+      if horizontal_flip: albu_array.append(A.HorizontalFlip())
 
-    if "rotate_limit" in config_aug_tfms: 
-      albu_array.append(A.ShiftScaleRotate(**config_aug_tfms["rotate_limit"]))
+    if "shift_scale_rotate" in config_aug_tfms: 
+      albu_array.append(A.ShiftScaleRotate(**config_aug_tfms["shift_scale_rotate"]))
 
     if "rgb_shift" in config_aug_tfms:
       albu_array.append(A.RGBShift(**config_aug_tfms["rgb_shift"]))
@@ -122,9 +139,8 @@ def aug_tfms_albumentations(config_aug_tfms=config_aug_tfms_train_pets):
     if "blur" in config_aug_tfms: 
       albu_array.append(A.Blur(**config_aug_tfms["blur"]))
 
-    if "images_stats" in config_aug_tfms:     
-      images_mean, images_std = config_aug_tfms["images_stats"]
-      albu_array.append(A.Normalize(mean=images_mean, std=images_std))
+    if "normalize" in config_aug_tfms:     
+      albu_array.append(A.Normalize(**config_aug_tfms["normalize"]))
 
     # return AlbuTransform  
     if albu_array:

--- a/mantisshrimp/transforms/albu_transform.py
+++ b/mantisshrimp/transforms/albu_transform.py
@@ -3,6 +3,7 @@ __all__ = ["AlbuTransform"]
 from mantisshrimp.imports import *
 from mantisshrimp.core import *
 from mantisshrimp.transforms.transform import *
+from mantisshrimp.utils.utils import *
 
 import albumentations as A
 


### PR DESCRIPTION
I added the following method `aug_tfms_albumentations(config_aug_tfms=config_aug_tfms_train_pets)` . It allows creating a pipeline of Albumentations transforms. We pass it a config object. 

`config_aug_tfms`: A dictionary of dictionaries. Each dictionary represents some valid arguments corresponding to a specific Albumentations Transform

After several iterations, I settled for the following convention:  

Each dictionary key corresponds to a particular Albumentations Transform
The conventions is the following:
```
"Snake Notation"                         <---> "Camel Case Notation" 
"longest_max_size"                      <---> LongestMaxSize
"random_sized_bbox_safe_crop" <---> RandomSizedBBoxSafeCrop
```

Each dictionary value represents some valid arguments corresponding to a specific Albumentations Transform
    e.g: 
    `"random_sized_bbox_safe_crop" <---> RandomSizedBBoxSafeCrop ---> {"height": 320, "width": 320, "p": 0.3}`

Out the box, we supply both `config_aug_tfms_train_pets` and `config_aug_tfms_valid_pets` objects for the PETS datasets. We will add new ones for the upcoming datasets.

I also added some documentation. The [01-getting_started](https://github.com/lgvaz/mantisshrimp/blob/master/tutorials/01-getting_started.ipynb) notebook is also updated 

Please Review: