### PR TITLE
Repackages code for pypi

### DIFF
--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Tests
+name: tests
 
 on:
   push:

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: CI All Test
+name: Tests
 
 on:
   push:

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: CI Test
+name: CI All Test
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov
         pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        pip install -e .
+        pip install -e .[all]
         pip install git+git://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
     - name: Lint with flake8
       run: |

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -30,6 +30,7 @@ jobs:
         pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
         pip install -e .[all]
         pip install git+git://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
+        pip install git+git://github.com/rwightman/efficientdet-pytorch.git
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: tests
+name: CI Test
 
 on:
   push:
@@ -28,10 +28,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov
         pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        xargs -n 1 -L 1 pip install < requirements.txt
-        pip install -r requirements-extra.txt
-        pip install git+git://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
         pip install -e .
+        pip install git+git://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,4 +1,0 @@
-pandas>=1.0.0
-albumentations>=0.4.5
-git+https://github.com/rwightman/efficientdet-pytorch.git
-omegaconf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,1 @@
-tqdm>=4.41.0
-matplotlib>=3.1.1
-pyyaml>=3.13
-tensorboard>=1.14
-opencv-python>=4.2.0
-pytorch-lightning>=0.7.6
-ipykernel
-fastai2>0.0.14
+git+https://github.com/rwightman/efficientdet-pytorch.git

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,9 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = fastcore torch torchvision
+requirements = fastcore tqdm matplotlib torch torchvision
+pytorch_lightning = pytorch-lightning
+fastai = fastai2
 # Optional. Same format as setuptools console_scripts
 # console_scripts =
 # Optional. Same format as setuptools dependency-links

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = fastcore tqdm matplotlib torch torchvision
+requirements = fastcore tqdm matplotlib cython opencv-python omegaconf ipykernel git+git://github.com/rwightman/efficientdet-pytorch.git
 pytorch_lightning = pytorch-lightning
 fastai = fastai2
 # Optional. Same format as setuptools console_scripts

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = fastcore tqdm matplotlib cython opencv-python omegaconf ipykernel git+git://github.com/rwightman/efficientdet-pytorch.git
+requirements = fastcore tqdm matplotlib cython opencv-python omegaconf ipykernel
 pytorch_lightning = pytorch-lightning
 fastai = fastai2
 # Optional. Same format as setuptools console_scripts

--- a/settings.ini
+++ b/settings.ini
@@ -28,7 +28,7 @@ status = 2
 requirements = fastcore tqdm matplotlib cython opencv-python omegaconf ipykernel
 pytorch_lightning = pytorch-lightning
 fastai = fastai2
-all = pytorch-lightning fastai2 pytest requests
+all = pytorch-lightning fastai2 pytest requests albumentations
 # Optional. Same format as setuptools console_scripts
 # console_scripts =
 # Optional. Same format as setuptools dependency-links

--- a/settings.ini
+++ b/settings.ini
@@ -28,6 +28,7 @@ status = 2
 requirements = fastcore tqdm matplotlib cython opencv-python omegaconf ipykernel
 pytorch_lightning = pytorch-lightning
 fastai = fastai2
+all = pytorch-lightning fastai2 pytest requests
 # Optional. Same format as setuptools console_scripts
 # console_scripts =
 # Optional. Same format as setuptools dependency-links

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,14 @@ extras = {}
 requirements = cfg.get("requirements", "").split()
 pl_req = cfg.get("pytorch_lightning", "").split()
 fs_req = cfg.get("fastai").split()
+all_req = cfg.get("all").split()
 
 lic = licenses[cfg["license"]]
 min_python = cfg["min_python"]
 
 extras["pytorch-lightning"] = pl_req
 extras["fastai"] = fs_req
-extras["all"] = pl_req + fs_req + ["pytest"]
+extras["all"] = all_req
 
 setuptools.setup(
     name=cfg["lib_name"],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ min_python = cfg["min_python"]
 
 extras["pytorch-lightning"] = pl_req
 extras["fastai"] = fs_req
-extras["all"] = pl_req + fs_req
+extras["all"] = pl_req + fs_req + ["pytest"]
 
 setuptools.setup(
     name=cfg["lib_name"],

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,17 @@ py_versions = (
     "2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8".split()
 )
 
+extras = {}
 requirements = cfg.get("requirements", "").split()
+pl_req = cfg.get("pytorch_lightning", "").split()
+fs_req = cfg.get("fastai").split()
+
 lic = licenses[cfg["license"]]
 min_python = cfg["min_python"]
+
+extras["pytorch-lightning"] = pl_req
+extras["fastai"] = fs_req
+extras["all"] = pl_req + fs_req
 
 setuptools.setup(
     name=cfg["lib_name"],
@@ -58,6 +66,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=requirements,
+    extras_require=extras,
     dependency_links=cfg.get("dep_links", "").split(),
     python_requires=">=" + cfg["min_python"],
     long_description=open("README.md", encoding="utf-8", errors="ignore").read(),


### PR DESCRIPTION
Updates for better PyPi packaging. Helps #182. #209

So now how the installation goes.
Note that

If we are at the repo root. then we do `pip install .` otherwise on PyPi we would just replace `.` with `mantisshrimp`

With this update, we will be able to install engines separately through `setup.py` itself. This follows the HuggingFace strategy exactly. Which we aimed for.
 
- To install mantisshrimp raw. without any engine
`pip install mantisshrimp` or if we have cloned and we are installing `pip install .`

- To install with Fastai.
`pip install mantisshrimp[fastai]` or if we have cloned and we are installing `pip install .[fastai]`

- To install with Pytorch-lightning
`pip install mantisshrimp[pytorch-lightning]` or if we have cloned and we are installing `pip install .[pytorch-lightning]`

To install completely with both the engines
`pip install mantisshrimp[all]` or if we have cloned and we are installing `pip install .[all]`

Note that we cannot provide the all option as default as these packages are built incrementally and that's what even HF follows.

We expect the user to have torch and torchvision pre-installed otherwise we do that for them.

I see our CI is kinda broke. It installs from `requirements.txt` and `requirements-extra.txt`. This will not work henceforth. If we are packaging this code then we should have `pip install .[all]` in our repo base and check for the tests. `requirements.txt` and `requirements-extra.txt` can completely be deleted then.

This CI change will ensure that what we build in `setup.py` is what we test and will be what we will deploy. Also it will ensure that correct requirements are listed in `settings.ini` and there is no discrepancy.

I will raise PR for CI change. Then re-run this to check for it.

This current installation method. I have checked locally all seem to be working good. Also, I will add a CI to deploy to PyPi when we tag a release later.
