### PR TITLE
Revamp CI for packaging

### DIFF
--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -12,9 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-2019, macOS-10.15]
         python-version: [3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -25,7 +25,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Setup Ubuntu
+      if: runner.os == 'ubuntu-latest'
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov
@@ -33,6 +34,26 @@ jobs:
         pip install -e .[all]
         pip install git+git://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
         pip install git+git://github.com/rwightman/efficientdet-pytorch.git
+
+    - name: Setup Windows
+      if: runner.os == 'windows'
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pytest-cov
+        pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install -e .[all]
+        pip install "git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI"
+        pip install git+git://github.com/rwightman/efficientdet-pytorch.git
+      
+    - name: Setup MacOS
+      if: runner.os == "MacOS"
+      run: |
+        python -m pip install --upgrade pip  
+        pip install torch torchvision
+        pip install -e .[all]
+        pip install git+git://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
+        pip install git+git://github.com/rwightman/efficientdet-pytorch.git
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,4 +1,4 @@
-name: PyPI Release
+name: PyPi Release
 
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,46 @@
+name: PyPI Release
+
+# https://help.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - created
+
+# based on https://github.com/pypa/gh-action-pypi-publish
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: >-
+        python -m pip install --user --upgrade setuptools wheel
+    - name: Build
+      run: >-
+        python setup.py sdist bdist_wheel
+    # We do this, since failures on test.pypi aren't that bad
+    - name: Publish to Test PyPI
+      if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
- With the current change I added CI for more OS systems. It is good idea to build on multiple OS before publishing.
- This technique is taken from PyTorch Lightning.

- I have added CI for releasing to both PyPi test server and PyPi official. This is again taken from Lightning